### PR TITLE
FIXED

### DIFF
--- a/core/genie.py
+++ b/core/genie.py
@@ -8,10 +8,15 @@ from langchain.vectorstores import Chroma
 from chromadb.utils import embedding_functions
 import dotenv
 import os
+import sys
 
 dotenv.load_dotenv()
 
-os.environ["OPENAI_API_KEY"] = os.getenv("OPENAI_API_KEY")
+if "OPENAI_API_KEY" not in os.environ:
+    print("Error: OPENAI_API_KEY environment variable is not set.")
+    sys.exit(1)
+
+os.environ["OPENAI_API_KEY"] = os.getenv("OPENAI_API_KEY", "")
 
 openai_ef = embedding_functions.OpenAIEmbeddingFunction(api_key=os.getenv("OPENAI_API_KEY"))
 vectorstore = Chroma(persist_directory="./chroma_db", embedding_function=openai_ef)
@@ -20,10 +25,8 @@ retriever = vectorstore.as_retriever()
 prompt = hub.pull("rlm/rag-prompt")
 llm = ChatOpenAI(model_name="gpt-3.5-turbo", temperature=0)
 
-
 def format_docs(docs):
     return "\n\n".join(doc.page_content for doc in docs)
-
 
 rag_chain = (
     {"context": retriever | format_docs, "question": RunnablePassthrough()}
@@ -33,4 +36,3 @@ rag_chain = (
 )
 
 rag_chain.invoke("What is Task Decomposition?")
-


### PR DESCRIPTION
Problem:
You were working on using Langchain RAG for your DocGenie project. The goal was to divide the process into two main steps: indexing, where you load documents and store embeddings, and retrieval, where you find the right embeddings to generate responses. You created two files, store.py for indexing and genie.py for answering questions using the stored data. However, when you ran genie.py, it threw an error.

Issue Details:
The error pointed to a problem with the OpenAI API key. Specifically, it said the "OPENAI_API_KEY" environment variable wasn't set.

Initial Attempt:
Originally, the code tried to set the "OPENAI_API_KEY" environment variable using os.environ["OPENAI_API_KEY"] = os.getenv("OPENAI_API_KEY").

Identified Problem:
The error happened because os.getenv("OPENAI_API_KEY") returned None when the environment variable wasn't set. Trying to assign this None value to os.environ["OPENAI_API_KEY"] caused a TypeError.

Solution Steps:
Checked if the "OPENAI_API_KEY" environment variable was already set using "OPENAI_API_KEY" not in os.environ.
If not set, printed an error message and exited the script using sys.exit(1).
Set the "OPENAI_API_KEY" environment variable using os.environ["OPENAI_API_KEY"] = os.getenv("OPENAI_API_KEY", ""). This ensured that if os.getenv("OPENAI_API_KEY") returned None, an empty string was used as a default value.
Result:
Now, the script checks if the "OPENAI_API_KEY" environment variable is set before using it. If the key is missing, the script prints an error message and exits, preventing the NoneType error.

User Action:
To run the script successfully, you just need to set the "OPENAI_API_KEY" environment variable in your environment or in a .env file before running the script